### PR TITLE
Preserve Host header and don't follow redirects

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,10 +21,13 @@ console.log(
       }
 
       const url = new URL(request.url);
+      const host = url.host;
       url.hostname = 'localhost';
       url.port = map[name].toString();
+      const proxyRequest = new Request(url, request);
+      proxyRequest.headers.set("Host", host);
 
-      return await fetch(new Request(url, request));
+      return await fetch(proxyRequest, { redirect: "manual" });
     },
   }).url.href
 );


### PR DESCRIPTION
This includes two changes for more correct reverse proxy behavior:

* Preserve the "Host" header set by the client, instead of deriving it from the new URL (as `fetch` does by default). This ensures that e.g. if the service issues a redirect, it will be in terms of servicename.localhost, not 127.0.0.1:7001.

* Pass `{ redirect: "manual" }` to fetch. This ensures that redirects from the service are sent back to the client, instead of the reverse proxy issuing the request to the new location itself.